### PR TITLE
convert HISTORY to Markdown

### DIFF
--- a/azure-cognitiveservices-vision-computervision/HISTORY.md
+++ b/azure-cognitiveservices-vision-computervision/HISTORY.md
@@ -1,26 +1,22 @@
-.. :changelog:
+## Release History
 
-Release History
-===============
+### 0.2.0 (2018-06-22)
 
-0.2.0 (2018-06-22)
-++++++++++++++++++
-
-**Features**
+#### Features
 
 - analyze_image now support 'en', 'es', 'ja', 'pt', 'zh' (including "in_stream" version of these operations)
 - describe_image/tag_image/analyze_image_by_domain now support the language parameter (including "in_stream" version of these operations)
 - Client class can be used as a context manager to keep the underlying HTTP session open for performance
 
-**Bug fixes**
+#### Bug fixes
 
 - Fix several invalid JSON description, that was raising unexpected exceptions (including OCRResult from bug #2614)
 
-**Breaking changes**
+#### Breaking changes
 
 - recognize_text "detect_handwriting" boolean is now a "mode" str between 'Handwritten' and 'Printed'
 
-**General Breaking changes**
+#### General breaking changes
 
 This version uses a next-generation code generator that *might* introduce breaking changes.
 
@@ -29,23 +25,20 @@ This version uses a next-generation code generator that *might* introduce breaki
 - Enum types now use the "str" mixin (class AzureEnum(str, Enum)) to improve the behavior when unrecognized enum values are encountered.
   While this is not a breaking change, the distinctions are important, and are documented here:
   https://docs.python.org/3/library/enum.html#others
-  At a glance:
 
+  At a glance:
   - "is" should not be used at all.
   - "format" will return the string value, where "%s" string formatting will return `NameOfEnum.stringvalue`. Format syntax should be prefered.
-
 - New Long Running Operation:
-
   - Return type changes from `msrestazure.azure_operation.AzureOperationPoller` to `msrest.polling.LROPoller`. External API is the same.
   - Return type is now **always** a `msrest.polling.LROPoller`, regardless of the optional parameters used.
-  - The behavior has changed when using `raw=True`. Instead of returning the initial call result as `ClientRawResponse`, 
+  - The behavior has changed when using `raw=True`. Instead of returning the initial call result as `ClientRawResponse`,
     without polling, now this returns an LROPoller. After polling, the final resource will be returned as a `ClientRawResponse`.
   - New `polling` parameter. The default behavior is `Polling=True` which will poll using ARM algorithm. When `Polling=False`,
     the response of the initial call will be returned without polling.
   - `polling` parameter accepts instances of subclasses of `msrest.polling.PollingMethod`.
   - `add_done_callback` will no longer raise if called after polling is finished, but will instead execute the callback right away.
 
-0.1.0 (2018-01-23)
-++++++++++++++++++
+### 0.1.0 (2018-01-23)
 
-* Initial Release
+- Initial release

--- a/azure-cognitiveservices-vision-computervision/README.md
+++ b/azure-cognitiveservices-vision-computervision/README.md
@@ -1,6 +1,6 @@
 # Azure Cognitive Services Computer Vision SDK for Python
 
-The Computer Vision service provides developers with access to advanced algorithms for processing images and returning information. Computer Vision algorithms analyze the content of an image in different ways, depending on the visual features you're interested in. For example, Computer Vision can determine if an image contains adult or racy content, find all the faces in an image, get handwritten or printed text. This service works with popular image formats, such as JPEG and PNG. 
+The Computer Vision service provides developers with access to advanced algorithms for processing images and returning information. Computer Vision algorithms analyze the content of an image in different ways, depending on the visual features you're interested in.
 
 You can use Computer Vision in your application to:
 
@@ -22,7 +22,7 @@ Looking for more documentation?
 If you need a Computer Vision API account, you can create one with this [Azure CLI][azure_cli] command:
 
 ```Bash
-RES_REGION=westeurope 
+RES_REGION=westeurope
 RES_GROUP=<resourcegroup-name>
 ACCT_NAME=<computervision-account-name>
 
@@ -60,7 +60,7 @@ pip install azure-cognitiveservices-vision-computervision
 
 Once you create your Computer Vision resource, you need its **region**, and one of its **account keys** to instantiate the client object.
 
-Use these values when you create the instance of the [ComputerVisionAPI][ref_computervisionclient] client object. 
+Use these values when you create the instance of the [ComputerVisionAPI][ref_computervisionclient] client object.
 
 ### Get credentials
 
@@ -104,9 +104,9 @@ client = ComputerVisionAPI(region, credentials)
 
 Once you've initialized a [ComputerVisionAPI][ref_computervisionclient] client object, you can:
 
-* Analyze an image: You can analyze an image for certain features such as faces, colors, tags.   
+* Analyze an image: You can analyze an image for certain features such as faces, colors, tags.
 * Generate thumbnails: Create a custom JPEG image to use as a thumbnail of the original image.
-* Get description of an image: Get a description of the image based on its subject domain. 
+* Get description of an image: Get a description of the image based on its subject domain.
 
 For more information about this service, see [What is Computer Vision?][computervision_docs].
 
@@ -147,11 +147,11 @@ for x in models.models_property:
 
 ### Analyze an image by domain
 
-You can analyze an image by subject domain with [`analyze_image_by_domain`][ref_computervisionclient_analyze_image_by_domain]. Get the [list of supported subject domains](#get-subject-domain-list) in order to use the correct domain name.  
+You can analyze an image by subject domain with [`analyze_image_by_domain`][ref_computervisionclient_analyze_image_by_domain]. Get the [list of supported subject domains](#get-subject-domain-list) in order to use the correct domain name.
 
 ```Python
 domain = "landmarks"
-url = "https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/Broadway_and_Times_Square_by_night.jpg/450px-Broadway_and_Times_Square_by_night.jpg"
+url = "https://images.pexels.com/photos/338515/pexels-photo-338515.jpeg"
 language = "en"
 
 analysis = client.analyze_image_by_domain(domain, url, language)
@@ -180,9 +180,13 @@ for caption in analysis.captions:
 
 ### Get text from image
 
-You can get any handwritten or printed text from an image. This requires two calls to the SDK: [`recognize_text`][ref_computervisionclient_recognize_text] and [`get_text_operation_result`][ref_computervisionclient_get_text_operation_result]. The call to recognize_text is asynchronous. In the results of the get_text_operation_result call, you need to check if the first call completed with [`TextOperationStatusCodes`][ref_computervision_model_textoperationstatuscodes] before extracting the text data. The results include the text as well as the bounding box coordinates for the text. 
+You can get any handwritten or printed text from an image. This requires two calls to the SDK: [`recognize_text`][ref_computervisionclient_recognize_text] and [`get_text_operation_result`][ref_computervisionclient_get_text_operation_result]. The call to recognize_text is asynchronous. In the results of the get_text_operation_result call, you need to check if the first call completed with [`TextOperationStatusCodes`][ref_computervision_model_textoperationstatuscodes] before extracting the text data. The results include the text as well as the bounding box coordinates for the text.
 
 ```Python
+# import models
+from azure.cognitiveservices.vision.computervision.models import TextRecognitionMode
+from azure.cognitiveservices.vision.computervision.models import TextOperationStatusCodes
+
 url = "https://azurecomcdn.azureedge.net/cvt-1979217d3d0d31c5c87cbd991bccfee2d184b55eeb4081200012bdaf6a65601a/images/shared/cognitive-services-demos/read-text/read-1-thumbnail.png"
 mode = TextRecognitionMode.handwritten
 raw = True
@@ -210,7 +214,7 @@ if result.status == TextOperationStatusCodes.succeeded:
 
 ### Generate thumbnail
 
-You can generate a thumbnail (JPG) of an image with [`generate_thumbnail`][ref_computervisionclient_generate_thumbnail]. The thumbnail does not need to be in the same proportions as the original image. 
+You can generate a thumbnail (JPG) of an image with [`generate_thumbnail`][ref_computervisionclient_generate_thumbnail]. The thumbnail does not need to be in the same proportions as the original image.
 
 This example uses the [Pillow][pypi_pillow] package to save the new thumbnail image locally.
 

--- a/azure-cognitiveservices-vision-computervision/setup.py
+++ b/azure-cognitiveservices-vision-computervision/setup.py
@@ -45,14 +45,14 @@ if not version:
 
 with open('README.md', encoding='utf-8') as f:
     readme = f.read()
-with open('HISTORY.rst', encoding='utf-8') as f:
+with open('HISTORY.md', encoding='utf-8') as f:
     history = f.read()
 
 setup(
     name=PACKAGE_NAME,
     version=version,
     description='Microsoft Azure {} Client Library for Python'.format(PACKAGE_PPRINT_NAME),
-    long_description=readme,
+    long_description=readme + '\n\n' + history,
     long_description_content_type='text/markdown',
     license='MIT License',
     author='Microsoft Corporation',


### PR DESCRIPTION
@diberry In addition to the HISTORY.rst -> HISTORY.md conversion, this also fixes the missing imports blocker and updates the image used for landmark to the Eiffel Tower. I've left most of the rest as-is so we can get this merged before the impending SDK update. I'll take another pass in a separate PR once the urgency has passed.